### PR TITLE
fix: wasm audio sync

### DIFF
--- a/src/platform/sdl/sdl-audio.c
+++ b/src/platform/sdl/sdl-audio.c
@@ -131,8 +131,10 @@ static void _mSDLAudioCallback(void* context, Uint8* data, int len) {
 	double fpsTarget = 60.0;
 	if (audioContext->fpsTarget > 0.0)
 		fpsTarget = audioContext->fpsTarget;
-	if (nowFramesInt > 0 )
+	if (nowFramesInt > 1 )
 		fpsTarget *= nowFrames;
+
+	emscripten_log(EM_LOG_CONSOLE, "vancise audio loop fps target: %f %f %f", fpsTarget, nowFrames, elapsedNow);
 
 	fauxClock = GBAAudioCalculateRatio(1, fpsTarget, 1);
 #endif

--- a/src/platform/sdl/sdl-audio.c
+++ b/src/platform/sdl/sdl-audio.c
@@ -113,7 +113,11 @@ static void _mSDLAudioCallback(void* context, Uint8* data, int len) {
 		mCoreSyncLockAudio(audioContext->sync);
 	}
 #ifdef __EMSCRIPTEN__
-	fauxClock = GBAAudioCalculateRatio(1, 60, 1);
+	double fpsTarget = 60.0;
+	if (audioContext->fpsTarget > 0.0) {
+		fpsTarget = audioContext->fpsTarget;
+	}
+	fauxClock = GBAAudioCalculateRatio(1, fpsTarget, 1);
 #endif
 	blip_set_rates(left, clockRate, audioContext->obtainedSpec.freq * fauxClock);
 	blip_set_rates(right, clockRate, audioContext->obtainedSpec.freq * fauxClock);

--- a/src/platform/sdl/sdl-audio.c
+++ b/src/platform/sdl/sdl-audio.c
@@ -12,10 +12,6 @@
 
 #include <mgba/core/blip_buf.h>
 
-#ifdef __EMSCRIPTEN__
-#include <emscripten.h>
-#endif
-
 #define BUFFER_SIZE (GBA_AUDIO_SAMPLES >> 2)
 
 mLOG_DEFINE_CATEGORY(SDL_AUDIO, "SDL Audio", "platform.sdl.audio");

--- a/src/platform/sdl/sdl-audio.c
+++ b/src/platform/sdl/sdl-audio.c
@@ -14,9 +14,6 @@
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
-
-// used for audio sync
-static double lastNow;
 #endif
 
 #define BUFFER_SIZE (GBA_AUDIO_SAMPLES >> 2)
@@ -120,21 +117,9 @@ static void _mSDLAudioCallback(void* context, Uint8* data, int len) {
 		mCoreSyncLockAudio(audioContext->sync);
 	}
 #ifdef __EMSCRIPTEN__
-	double now = emscripten_get_now();
-	double elapsedNow = now - (lastNow > 0.0 ? lastNow : now);
-	double nowFrames = elapsedNow / (1000.0 / 60.0); // 60fps target
-
-	lastNow = now;
-
-	Uint32 nowFramesInt = round(nowFrames - 0.3);
-
 	double fpsTarget = 60.0;
 	if (audioContext->fpsTarget > 0.0)
 		fpsTarget = audioContext->fpsTarget;
-	if (nowFramesInt > 1 )
-		fpsTarget *= nowFrames;
-
-	emscripten_log(EM_LOG_CONSOLE, "vancise audio loop fps target: %f %f %f", fpsTarget, nowFrames, elapsedNow);
 
 	fauxClock = GBAAudioCalculateRatio(1, fpsTarget, 1);
 #endif

--- a/src/platform/sdl/sdl-audio.h
+++ b/src/platform/sdl/sdl-audio.h
@@ -28,6 +28,7 @@ struct mSDLAudio {
 	// Input
 	size_t samples;
 	unsigned sampleRate;
+	double fpsTarget;
 
 	// State
 	SDL_AudioSpec desiredSpec;

--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -21,7 +21,7 @@ static struct mCore* core = NULL;
 static color_t* buffer = NULL;
 static struct mSDLAudio audio = {
 	.sampleRate = 48000,
-	.samples = 1024,
+	.samples = 512,
 	.fpsTarget = 60.0,
 };
 
@@ -85,8 +85,6 @@ void testLoop() {
 
 		if (nowFramesInt > 20)
 			nowFramesInt = 20;
-
-		emscripten_log(EM_LOG_CONSOLE, "vancise after ff calc: %d %f %f", nowFramesInt, nowFrames, elapsedNow);
 
 		if (renderFirstFrame) {
 			renderFirstFrame = false;

--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -71,9 +71,9 @@ void testLoop() {
 		double now = emscripten_get_now();
 		double elapsedNow = now - (lastNow > 0.0 ? lastNow : now);
 		double nowFrames = elapsedNow / (1000.0 / 60.0); // 60fps target
-
 		lastNow = now;
 
+		// custom rounding, we want to prefer rounding down slightly
 		Uint32 nowFramesInt = round(nowFrames - 0.3);
 
 		if (nowFramesInt < 1) {

--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -70,11 +70,11 @@ void testLoop() {
 	if (core) {
 		double now = emscripten_get_now();
 		double elapsedNow = now - (lastNow > 0.0 ? lastNow : now);
-		double nowFrames = elapsedNow / (1000.0 / 60.0);  // 60fps target
+		double nowFrames = elapsedNow / (1000.0 / 60.0); // 60fps target
 
 		lastNow = now;
 
-		Uint32 nowFramesInt = (int) round(nowFrames - 0.25);
+		Uint32 nowFramesInt = round(nowFrames - 0.3);
 
 		if (nowFramesInt < 1) {
 			nowFramesInt = 1;
@@ -85,6 +85,8 @@ void testLoop() {
 
 		if (nowFramesInt > 20)
 			nowFramesInt = 20;
+
+		emscripten_log(EM_LOG_CONSOLE, "vancise after ff calc: %d %f %f", nowFramesInt, nowFrames, elapsedNow);
 
 		if (renderFirstFrame) {
 			renderFirstFrame = false;
@@ -196,7 +198,7 @@ EMSCRIPTEN_KEEPALIVE void setMainLoopTiming(int mode, int value) {
 }
 
 EMSCRIPTEN_KEEPALIVE void setFastForwardMultiplier(int multiplier) {
-	if (multiplier > 0){
+	if (multiplier > 0) {
 		fastForwardSpeed = multiplier;
 		audio.fpsTarget = (double) 60 * multiplier;
 

--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -317,6 +317,7 @@ EMSCRIPTEN_KEEPALIVE bool loadGame(const char* name) {
 	int stride;
 	SDL_LockTexture(tex, 0, (void**) &buffer, &stride);
 	core->setVideoBuffer(core, buffer, stride / BYTES_PER_PIXEL);
+	core->setAudioBufferSize(core, audio.samples * 8);
 
 	core->reset(core);
 

--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -21,7 +21,7 @@ static struct mCore* core = NULL;
 static color_t* buffer = NULL;
 static struct mSDLAudio audio = {
 	.sampleRate = 48000,
-	.samples = 512,
+	.samples = 1024,
 	.fpsTarget = 60.0,
 };
 
@@ -232,10 +232,12 @@ EMSCRIPTEN_KEEPALIVE void quickReload() {
 
 EMSCRIPTEN_KEEPALIVE void pauseGame() {
 	renderFirstFrame = true;
+	mSDLPauseAudio(&audio);
 	emscripten_pause_main_loop();
 }
 
 EMSCRIPTEN_KEEPALIVE void resumeGame() {
+	mSDLResumeAudio(&audio);
 	emscripten_resume_main_loop();
 }
 


### PR DESCRIPTION
### High Level Details

- first pass attempt at having smoother audio across the board

- the main goal here was to scale the audio when fast forwarding, as well as reduce rounding jitter and prefer rounding down when doing frame delta calculations

### TODO

I think more could be done to smooth things in the right direction in low power mode, the hard part is detection. But for now this seems like an acceptable first pass.

Supports: https://github.com/thenick775/gbajs3/issues/138