### PR TITLE
fix: addCoreCallbacks clearing thread callbacks

### DIFF
--- a/include/mgba/core/thread.h
+++ b/include/mgba/core/thread.h
@@ -130,6 +130,8 @@ void mCoreThreadRewindParamsChanged(struct mCoreThread* threadContext);
 
 struct mCoreThread* mCoreThreadGet(void);
 
+void mCoreThreadAddCoreCallbacks(struct mCoreThread* threadContext);
+
 CXX_GUARD_END
 
 #endif

--- a/src/core/thread.c
+++ b/src/core/thread.c
@@ -245,6 +245,19 @@ static void _mCoreThreadAddCallbacks(struct mCoreThread* threadContext) {
 }
 #endif
 
+void mCoreThreadAddCoreCallbacks(struct mCoreThread* threadContext) {
+	struct mCore* core = threadContext->core;
+	struct mCoreCallbacks callbacks = {
+		.videoFrameStarted = _frameStarted,
+		.videoFrameEnded = _frameEnded,
+		.coreCrashed = _crashed,
+		.sleep = _coreSleep,
+		.shutdown = _coreShutdown,
+		.context = threadContext
+	};
+	core->addCoreCallbacks(core, &callbacks);
+}
+
 static THREAD_ENTRY _mCoreThreadRun(void* context) {
 	struct mCoreThread* threadContext = context;
 #ifdef USE_PTHREADS

--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -457,6 +457,11 @@ EMSCRIPTEN_KEEPALIVE void addCoreCallbacks(void (*alarmCallbackPtr)(void*), void
 	if (renderer->core) {
 		struct mCoreCallbacks callbacks = {};
 		renderer->core->clearCoreCallbacks(renderer->core);
+		// the thread has its own suite of callbacks where ours should overlay on top,
+		// after clearing the current core callbacks since there is not a mechanism to
+		// filter the callbacks, we need to re-add the thread callbacks
+		if (renderer->thread)
+			mCoreThreadAddCoreCallbacks(renderer->thread);
 
 		// store original function pointers
 		if (alarmCallbackPtr)


### PR DESCRIPTION
- our custom "scripting" style callbacks should always overlay the regular thread callbacks that support things like rewind