### PR TITLE
fix: loading game while running

### DIFF
--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -389,12 +389,8 @@ EMSCRIPTEN_KEEPALIVE bool autoLoadCheats() {
 }
 
 EMSCRIPTEN_KEEPALIVE bool loadGame(const char* name, const char* savePathOverride) {
-	if (renderer->core) {
-		renderer->core->unloadROM(renderer->core);
-		mCoreConfigDeinit(&renderer->core->config);
-		mInputMapDeinit(&renderer->core->inputMap);
-		renderer->core->deinit(renderer->core);
-		renderer->core = NULL;
+	if (renderer->thread && renderer->core) {
+		quitGame();
 	}
 	renderer->core = mCoreFind(name);
 	if (!renderer->core) {

--- a/src/platform/wasm/package.json
+++ b/src/platform/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thenick775/mgba-wasm",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "mGBA emulator compiled to webassembly",
   "main": "./dist/mgba.js",
   "types": "./dist/mgba.d.ts",


### PR DESCRIPTION
### High Level Details

- we permit loading a rom while another rom is running
- the logic here did not account for the move to threads in #14
- when a core was loaded, the memory was freed and the config map checked in the hot loop of the thread would cause a crash with memory access out of bounds
   - see: https://github.com/thenick775/gbajs3/issues/318
- quitGame takes into account the thread, core, and audio "deinit"s, and should be used on repeated loads