### PR TITLE
feat: auto save state in wasm platform

### DIFF
--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -169,10 +169,64 @@ EMSCRIPTEN_KEEPALIVE void quitMgba() {
 	exit(0);
 }
 
+EMSCRIPTEN_KEEPALIVE bool autoSaveState() {
+	if (renderer->core) {
+		EM_ASM({ console.log('attempting to save auto save state') });
+		bool result = false;
+		struct VDir* autosaveDir = VDirOpen("/autosave");
+		char autoSaveName[PATH_MAX + 14];
+		snprintf(autoSaveName, sizeof(autoSaveName), "%s_auto.ss", renderer->core->dirs.baseName);
+
+		struct VFile* vf = autosaveDir->openFile(autosaveDir, autoSaveName, (O_CREAT | O_TRUNC | O_RDWR));
+
+		if (!vf)
+			return false;
+
+		result = mCoreSaveStateNamed(renderer->core, vf, SAVESTATE_ALL);
+		bool successfullyClosed = vf->close(vf);
+
+		EM_ASM({ console.log('auto save state completed with result', $0) }, result && successfullyClosed);
+		return result && successfullyClosed;
+	}
+
+	return false;
+}
+
+EMSCRIPTEN_KEEPALIVE bool loadAutoSaveState() {
+	bool result = false;
+	if (renderer->core && renderer->thread) {
+		EM_ASM({ console.log('attempting to load auto save state') });
+		struct VDir* autosaveDir = VDirOpen("/autosave");
+		char autoSaveName[PATH_MAX + 14];
+		snprintf(autoSaveName, sizeof(autoSaveName), "%s_auto.ss", renderer->core->dirs.baseName);
+
+		struct VFile* vf = autosaveDir->openFile(autosaveDir, autoSaveName, O_RDONLY);
+
+		EM_ASM({ console.log('vf', $0) }, vf);
+
+		if (!vf) {
+			EM_ASM({ console.log('no vfile returning false early') });
+			return false;
+		}
+
+		mCoreThreadInterrupt(renderer->thread);
+		result = mCoreLoadStateNamed(renderer->core, vf, SAVESTATE_ALL);
+		mCoreThreadContinue(renderer->thread);
+		EM_ASM({ console.log('loaded auto save state, result:', $0) }, result);
+		return result;
+	}
+	return false;
+}
+
 EMSCRIPTEN_KEEPALIVE void quickReload() {
 	if (renderer->core && renderer->thread) {
 		mCoreThreadInterrupt(renderer->thread);
+
 		renderer->core->reset(renderer->core);
+
+		if (renderer->restoreAutoSaveStateOnLoad)
+			loadAutoSaveState();
+
 		mCoreThreadContinue(renderer->thread);
 	}
 }
@@ -240,55 +294,6 @@ EMSCRIPTEN_KEEPALIVE bool loadState(int slot) {
 		mCoreThreadInterrupt(renderer->thread);
 		result = mCoreLoadState(renderer->core, slot, SAVESTATE_ALL);
 		mCoreThreadContinue(renderer->thread);
-		return result;
-	}
-	return false;
-}
-
-EMSCRIPTEN_KEEPALIVE bool autoSaveState() {
-	if (renderer->core) {
-		EM_ASM({ console.log('attempting to save auto save state') });
-		bool result = false;
-		struct VDir* autosaveDir = VDirOpen("/autosave");
-		char autoSaveName[PATH_MAX + 14];
-		snprintf(autoSaveName, sizeof(autoSaveName), "%s_auto.ss", renderer->core->dirs.baseName);
-
-		struct VFile* vf = autosaveDir->openFile(autosaveDir, autoSaveName, (O_CREAT | O_TRUNC | O_RDWR));
-
-		if (!vf)
-			return false;
-
-		result = mCoreSaveStateNamed(renderer->core, vf, SAVESTATE_ALL);
-		bool successfullyClosed = vf->close(vf);
-
-		EM_ASM({ console.log('auto save state completed with result', $0) }, result && successfullyClosed);
-		return result && successfullyClosed;
-	}
-
-	return false;
-}
-
-EMSCRIPTEN_KEEPALIVE bool loadAutoSaveState() {
-	bool result = false;
-	if (renderer->core && renderer->thread) {
-		EM_ASM({ console.log('attempting to load auto save state') });
-		struct VDir* autosaveDir = VDirOpen("/autosave");
-		char autoSaveName[PATH_MAX + 14];
-		snprintf(autoSaveName, sizeof(autoSaveName), "%s_auto.ss", renderer->core->dirs.baseName);
-
-		struct VFile* vf = autosaveDir->openFile(autosaveDir, autoSaveName, O_RDONLY);
-
-		EM_ASM({ console.log('vf', $0) }, vf);
-
-		if (!vf) {
-			EM_ASM({ console.log('no vfile returning false early') });
-			return false;
-		}
-
-		mCoreThreadInterrupt(renderer->thread);
-		result = mCoreLoadStateNamed(renderer->core, vf, SAVESTATE_ALL);
-		mCoreThreadContinue(renderer->thread);
-		EM_ASM({ console.log('loaded auto save state, result:', $0) }, result);
 		return result;
 	}
 	return false;

--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -199,6 +199,8 @@ EMSCRIPTEN_KEEPALIVE void quitGame() {
 		renderer->core->deinit(renderer->core);
 		renderer->core = NULL;
 		renderer->audio.core = NULL;
+
+		renderer->autoSaveStateTimer.lastTime = 0;
 	}
 }
 
@@ -270,6 +272,8 @@ EMSCRIPTEN_KEEPALIVE void pauseGame() {
 
 	if (renderer->thread)
 		mCoreThreadPause(renderer->thread);
+
+	renderer->autoSaveStateTimer.lastTime = 0;
 
 	emscripten_pause_main_loop();
 }

--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -270,7 +270,7 @@ EMSCRIPTEN_KEEPALIVE bool autoSaveState() {
 
 EMSCRIPTEN_KEEPALIVE bool loadAutoSaveState() {
 	bool result = false;
-	if (renderer->core) {
+	if (renderer->core && renderer->thread) {
 		EM_ASM({ console.log('attempting to load auto save state') });
 		struct VDir* autosaveDir = VDirOpen("/autosave");
 		char autoSaveName[PATH_MAX + 14];
@@ -285,7 +285,9 @@ EMSCRIPTEN_KEEPALIVE bool loadAutoSaveState() {
 			return false;
 		}
 
+		mCoreThreadInterrupt(renderer->thread);
 		result = mCoreLoadStateNamed(renderer->core, vf, SAVESTATE_ALL);
+		mCoreThreadContinue(renderer->thread);
 		EM_ASM({ console.log('loaded auto save state, result:', $0) }, result);
 		return result;
 	}

--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -29,154 +29,6 @@ static struct mEmscriptenRenderer* renderer = NULL;
 static void _log(struct mLogger*, int category, enum mLogLevel level, const char* format, va_list args);
 static struct mLogger logCtx = { .log = _log };
 
-// full handling of fast forward, interrupts and thread logic included
-void updateFastForward(int multiplier) {
-	if (renderer->thread && renderer->videoSync) {
-		mCoreThreadInterrupt(renderer->thread);
-		renderer->thread->impl->sync.videoFrameWait = (multiplier > 1) ? false : renderer->videoSync;
-		renderer->thread->impl->sync.audioWait = (multiplier > 1) ? true : renderer->audioSync;
-		mCoreThreadContinue(renderer->thread);
-	}
-
-	if (renderer->core && renderer->thread && multiplier > 0) {
-		renderer->thread->impl->sync.fpsTarget = (double) renderer->baseFpsTarget * multiplier;
-		mCoreConfigSetDefaultFloatValue(&renderer->core->config, "fpsTarget",
-		                                (double) renderer->baseFpsTarget * multiplier);
-		renderer->core->reloadConfigOption(renderer->core, "fpsTarget", &renderer->core->config);
-
-		if (renderer->frameSkip == 0) {
-			// fast forward starts at 1, frameskip starts at 0
-			mCoreConfigSetDefaultIntValue(&renderer->core->config, "frameskip", multiplier - 1);
-			renderer->core->reloadConfigOption(renderer->core, "frameskip", &renderer->core->config);
-		}
-	}
-}
-
-// keypress utilities
-static void handleKeypressCore(const struct SDL_KeyboardEvent* event) {
-	if (event->keysym.sym == SDLK_f && renderer->fastForwardMultiplier == 1) {
-		updateFastForward(event->type == SDL_KEYDOWN ? 2 : 1);
-		return;
-	}
-	if (event->keysym.sym == SDLK_r) {
-		mCoreThreadSetRewinding(renderer->thread, event->type == SDL_KEYDOWN);
-		return;
-	}
-	int key = -1;
-	if (!(event->keysym.mod & ~(KMOD_NUM | KMOD_CAPS))) {
-		key = mInputMapKey(&renderer->core->inputMap, SDL_BINDING_KEY, event->keysym.sym);
-	}
-	if (key != -1) {
-		if (event->type == SDL_KEYDOWN) {
-			renderer->core->addKeys(renderer->core, 1 << key);
-		} else {
-			renderer->core->clearKeys(renderer->core, 1 << key);
-		}
-	}
-}
-
-// fps utilities
-void updateFPS() {
-	double now = emscripten_get_now();
-
-	if (renderer->fpsCounter.lastTime == 0) {
-		renderer->fpsCounter.lastTime = now;
-		return;
-	}
-
-	renderer->fpsCounter.frames++;
-
-	double elapsed = now - renderer->fpsCounter.lastTime;
-	if (elapsed >= 1000.0) { // every ~1 second
-		renderer->fpsCounter.fps = (double) renderer->fpsCounter.frames * 1000.0 / elapsed;
-		renderer->fpsCounter.frames = 0;
-		renderer->fpsCounter.lastTime = now;
-	}
-}
-
-void drawFPS(unsigned x, unsigned y) {
-	char fpsBuf[32];
-	snprintf(fpsBuf, sizeof(fpsBuf), "%.1f", renderer->fpsCounter.fps);
-
-	int scale = 1;
-	int charWidth = 8 * scale;
-	int charHeight = 10 * scale;
-	int width = strlen(fpsBuf) * charWidth;
-	int height = charHeight;
-
-	// save current draw color
-	Uint8 prevR, prevG, prevB, prevA;
-	SDL_GetRenderDrawColor(renderer->sdlRenderer, &prevR, &prevG, &prevB, &prevA);
-
-	// draw gray background
-	SDL_SetRenderDrawColor(renderer->sdlRenderer, 64, 64, 64, 255);
-	SDL_FRect bgRect = { x - 2, y - 2, width + 4, height + 4 };
-	SDL_RenderFillRectF(renderer->sdlRenderer, &bgRect);
-
-	// draw white text
-	SDL_SetRenderDrawColor(renderer->sdlRenderer, 255, 255, 255, 255);
-	SDL_RenderText(renderer->sdlRenderer, fpsBuf, scale, x, y);
-
-	// restore original draw color
-	SDL_SetRenderDrawColor(renderer->sdlRenderer, prevR, prevG, prevB, prevA);
-}
-
-// emscripten main run loop
-void runLoop() {
-	union SDL_Event event;
-
-	if (renderer->core) {
-		if (!renderer->thread) {
-			renderer->thread = malloc(sizeof(struct mCoreThread));
-			memset(renderer->thread, 0, sizeof(struct mCoreThread));
-
-			renderer->thread->core = renderer->core;
-			bool didFail = !mCoreThreadStart(renderer->thread);
-			if (didFail)
-				EM_ASM({ console.error("thread instantiation failed") });
-
-			mSDLInitAudio(&renderer->audio, renderer->thread);
-			mSDLResumeAudio(&renderer->audio);
-			updateFastForward(renderer->fastForwardMultiplier);
-		}
-
-		if (mCoreThreadIsActive(renderer->thread)) {
-			while (SDL_PollEvent(&event)) {
-				switch (event.type) {
-				case SDL_KEYDOWN:
-				case SDL_KEYUP:
-					if (renderer->core && renderer->thread) {
-						handleKeypressCore(&event.key);
-					}
-					break;
-				};
-			}
-			if (mCoreSyncWaitFrameStart(&renderer->thread->impl->sync)) {
-				unsigned w, h;
-				renderer->core->currentVideoSize(renderer->core, &w, &h);
-
-				SDL_Rect rect = { .x = 0, .y = 0, .w = w, .h = h };
-
-				SDL_UnlockTexture(renderer->sdlTex);
-				SDL_RenderCopy(renderer->sdlRenderer, renderer->sdlTex, &rect, &rect);
-				if (renderer->showFpsCounter)
-					drawFPS(w - 35, h - LINE_HEIGHT);
-				SDL_RenderPresent(renderer->sdlRenderer);
-				int stride;
-				SDL_LockTexture(renderer->sdlTex, 0, (void**) &renderer->outputBuffer, &stride);
-				renderer->core->setVideoBuffer(renderer->core, renderer->outputBuffer, stride / BYTES_PER_PIXEL);
-			}
-			mCoreSyncWaitFrameEnd(&renderer->thread->impl->sync);
-		}
-		if (renderer->showFpsCounter)
-			updateFPS();
-	} else {
-		// dont run the main loop if there is no core,  we don't
-		// want to handle events unless the core is running for now
-		emscripten_pause_main_loop();
-	}
-}
-
 /**
  * Exposed core contract methods
  */
@@ -257,6 +109,29 @@ EMSCRIPTEN_KEEPALIVE int getMainLoopTimingValue() {
 
 EMSCRIPTEN_KEEPALIVE void setMainLoopTiming(int mode, int value) {
 	emscripten_set_main_loop_timing(mode, value);
+}
+
+// full handling of fast forward, interrupts and thread logic included
+void updateFastForward(int multiplier) {
+	if (renderer->thread && renderer->videoSync) {
+		mCoreThreadInterrupt(renderer->thread);
+		renderer->thread->impl->sync.videoFrameWait = (multiplier > 1) ? false : renderer->videoSync;
+		renderer->thread->impl->sync.audioWait = (multiplier > 1) ? true : renderer->audioSync;
+		mCoreThreadContinue(renderer->thread);
+	}
+
+	if (renderer->core && renderer->thread && multiplier > 0) {
+		renderer->thread->impl->sync.fpsTarget = (double) renderer->baseFpsTarget * multiplier;
+		mCoreConfigSetDefaultFloatValue(&renderer->core->config, "fpsTarget",
+		                                (double) renderer->baseFpsTarget * multiplier);
+		renderer->core->reloadConfigOption(renderer->core, "fpsTarget", &renderer->core->config);
+
+		if (renderer->frameSkip == 0) {
+			// fast forward starts at 1, frameskip starts at 0
+			mCoreConfigSetDefaultIntValue(&renderer->core->config, "frameskip", multiplier - 1);
+			renderer->core->reloadConfigOption(renderer->core, "frameskip", &renderer->core->config);
+		}
+	}
 }
 
 EMSCRIPTEN_KEEPALIVE void setFastForwardMultiplier(int multiplier) {
@@ -630,6 +505,139 @@ EMSCRIPTEN_KEEPALIVE void setIntegerCoreSetting(char* settingName, int value) {
 		}
 	}
 }
+
+/*
+ * Rendering utilities and emscripten main rendering loop
+ */
+
+// keypress utilities
+static void handleKeypressCore(const struct SDL_KeyboardEvent* event) {
+	if (event->keysym.sym == SDLK_f && renderer->fastForwardMultiplier == 1) {
+		updateFastForward(event->type == SDL_KEYDOWN ? 2 : 1);
+		return;
+	}
+	if (event->keysym.sym == SDLK_r) {
+		mCoreThreadSetRewinding(renderer->thread, event->type == SDL_KEYDOWN);
+		return;
+	}
+	int key = -1;
+	if (!(event->keysym.mod & ~(KMOD_NUM | KMOD_CAPS))) {
+		key = mInputMapKey(&renderer->core->inputMap, SDL_BINDING_KEY, event->keysym.sym);
+	}
+	if (key != -1) {
+		if (event->type == SDL_KEYDOWN) {
+			renderer->core->addKeys(renderer->core, 1 << key);
+		} else {
+			renderer->core->clearKeys(renderer->core, 1 << key);
+		}
+	}
+}
+
+// fps utilities
+void updateFPS() {
+	double now = emscripten_get_now();
+
+	if (renderer->fpsCounter.lastTime == 0) {
+		renderer->fpsCounter.lastTime = now;
+		return;
+	}
+
+	renderer->fpsCounter.frames++;
+
+	double elapsed = now - renderer->fpsCounter.lastTime;
+	if (elapsed >= 1000.0) { // every ~1 second
+		renderer->fpsCounter.fps = (double) renderer->fpsCounter.frames * 1000.0 / elapsed;
+		renderer->fpsCounter.frames = 0;
+		renderer->fpsCounter.lastTime = now;
+	}
+}
+
+void drawFPS(unsigned x, unsigned y) {
+	char fpsBuf[32];
+	snprintf(fpsBuf, sizeof(fpsBuf), "%.1f", renderer->fpsCounter.fps);
+
+	int scale = 1;
+	int charWidth = 8 * scale;
+	int charHeight = 10 * scale;
+	int width = strlen(fpsBuf) * charWidth;
+	int height = charHeight;
+
+	// save current draw color
+	Uint8 prevR, prevG, prevB, prevA;
+	SDL_GetRenderDrawColor(renderer->sdlRenderer, &prevR, &prevG, &prevB, &prevA);
+
+	// draw gray background
+	SDL_SetRenderDrawColor(renderer->sdlRenderer, 64, 64, 64, 255);
+	SDL_FRect bgRect = { x - 2, y - 2, width + 4, height + 4 };
+	SDL_RenderFillRectF(renderer->sdlRenderer, &bgRect);
+
+	// draw white text
+	SDL_SetRenderDrawColor(renderer->sdlRenderer, 255, 255, 255, 255);
+	SDL_RenderText(renderer->sdlRenderer, fpsBuf, scale, x, y);
+
+	// restore original draw color
+	SDL_SetRenderDrawColor(renderer->sdlRenderer, prevR, prevG, prevB, prevA);
+}
+
+// emscripten main run loop
+void runLoop() {
+	union SDL_Event event;
+
+	if (renderer->core) {
+		if (!renderer->thread) {
+			renderer->thread = malloc(sizeof(struct mCoreThread));
+			memset(renderer->thread, 0, sizeof(struct mCoreThread));
+
+			renderer->thread->core = renderer->core;
+			bool didFail = !mCoreThreadStart(renderer->thread);
+			if (didFail)
+				EM_ASM({ console.error("thread instantiation failed") });
+
+			mSDLInitAudio(&renderer->audio, renderer->thread);
+			mSDLResumeAudio(&renderer->audio);
+			updateFastForward(renderer->fastForwardMultiplier);
+		}
+
+		if (mCoreThreadIsActive(renderer->thread)) {
+			while (SDL_PollEvent(&event)) {
+				switch (event.type) {
+				case SDL_KEYDOWN:
+				case SDL_KEYUP:
+					if (renderer->core && renderer->thread) {
+						handleKeypressCore(&event.key);
+					}
+					break;
+				};
+			}
+			if (mCoreSyncWaitFrameStart(&renderer->thread->impl->sync)) {
+				unsigned w, h;
+				renderer->core->currentVideoSize(renderer->core, &w, &h);
+
+				SDL_Rect rect = { .x = 0, .y = 0, .w = w, .h = h };
+
+				SDL_UnlockTexture(renderer->sdlTex);
+				SDL_RenderCopy(renderer->sdlRenderer, renderer->sdlTex, &rect, &rect);
+				if (renderer->showFpsCounter)
+					drawFPS(w - 35, h - LINE_HEIGHT);
+				SDL_RenderPresent(renderer->sdlRenderer);
+				int stride;
+				SDL_LockTexture(renderer->sdlTex, 0, (void**) &renderer->outputBuffer, &stride);
+				renderer->core->setVideoBuffer(renderer->core, renderer->outputBuffer, stride / BYTES_PER_PIXEL);
+			}
+			mCoreSyncWaitFrameEnd(&renderer->thread->impl->sync);
+		}
+		if (renderer->showFpsCounter)
+			updateFPS();
+	} else {
+		// dont run the main loop if there is no core,  we don't
+		// want to handle events unless the core is running for now
+		emscripten_pause_main_loop();
+	}
+}
+
+/*
+ * Initialization and main method (entrypoint)
+ */
 
 void _log(struct mLogger* logger, int category, enum mLogLevel level, const char* format, va_list args) {
 	UNUSED(logger);

--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -207,7 +207,7 @@ EMSCRIPTEN_KEEPALIVE void quitMgba() {
 }
 
 EMSCRIPTEN_KEEPALIVE bool autoSaveState() {
-	if (renderer->core) {
+	if (renderer->core && renderer->thread) {
 		EM_ASM({ console.log('attempting to save auto save state') });
 		bool result = false;
 		struct VDir* autosaveDir = VDirOpen("/autosave");
@@ -219,7 +219,9 @@ EMSCRIPTEN_KEEPALIVE bool autoSaveState() {
 		if (!vf)
 			return false;
 
+		mCoreThreadInterrupt(renderer->thread);
 		result = mCoreSaveStateNamed(renderer->core, vf, SAVESTATE_ALL);
+		mCoreThreadContinue(renderer->thread);
 		bool successfullyClosed = vf->close(vf);
 
 		EM_ASM({ console.log('auto save state completed with result', $0) }, result && successfullyClosed);

--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -245,6 +245,53 @@ EMSCRIPTEN_KEEPALIVE bool loadState(int slot) {
 	return false;
 }
 
+EMSCRIPTEN_KEEPALIVE bool autoSaveState() {
+	if (renderer->core) {
+		EM_ASM({ console.log('attempting to save auto save state') });
+		bool result = false;
+		struct VDir* autosaveDir = VDirOpen("/autosave");
+		char autoSaveName[PATH_MAX + 14];
+		snprintf(autoSaveName, sizeof(autoSaveName), "%s_auto.ss", renderer->core->dirs.baseName);
+
+		struct VFile* vf = autosaveDir->openFile(autosaveDir, autoSaveName, (O_CREAT | O_TRUNC | O_RDWR));
+
+		if (!vf)
+			return false;
+
+		result = mCoreSaveStateNamed(renderer->core, vf, SAVESTATE_ALL);
+		bool successfullyClosed = vf->close(vf);
+
+		EM_ASM({ console.log('auto save state completed with result', $0) }, result && successfullyClosed);
+		return result && successfullyClosed;
+	}
+
+	return false;
+}
+
+EMSCRIPTEN_KEEPALIVE bool loadAutoSaveState() {
+	bool result = false;
+	if (renderer->core) {
+		EM_ASM({ console.log('attempting to load auto save state') });
+		struct VDir* autosaveDir = VDirOpen("/autosave");
+		char autoSaveName[PATH_MAX + 14];
+		snprintf(autoSaveName, sizeof(autoSaveName), "%s_auto.ss", renderer->core->dirs.baseName);
+
+		struct VFile* vf = autosaveDir->openFile(autosaveDir, autoSaveName, O_RDONLY);
+
+		EM_ASM({ console.log('vf', $0) }, vf);
+
+		if (!vf) {
+			EM_ASM({ console.log('no vfile returning false early') });
+			return false;
+		}
+
+		result = mCoreLoadStateNamed(renderer->core, vf, SAVESTATE_ALL);
+		EM_ASM({ console.log('loaded auto save state, result:', $0) }, result);
+		return result;
+	}
+	return false;
+}
+
 // loads all cheats files located in the cores cheatsPath,
 // cheat files must match the name of the rom they are
 // to be applied to, and must end with the extension .cheats
@@ -461,6 +508,12 @@ EMSCRIPTEN_KEEPALIVE void setIntegerCoreSetting(char* settingName, int value) {
 		renderer->timestepSync = value;
 	} else if (strcmp(settingName, "showFpsCounter") == 0 && (value == true || value == false)) {
 		renderer->showFpsCounter = value;
+	} else if (strcmp(settingName, "autoSaveStateEnable") == 0 && (value == true || value == false)) {
+		renderer->autoSaveStateEnable = value;
+	} else if (strcmp(settingName, "restoreAutoSaveStateOnLoad") == 0 && (value == true || value == false)) {
+		renderer->restoreAutoSaveStateOnLoad = value;
+	} else if (strcmp(settingName, "autoSaveStateTimerIntervalSeconds") == 0 && value > 0) {
+		renderer->autoSaveStateTimer.intervalSeconds = value;
 	}
 
 	// core settings when running
@@ -579,6 +632,23 @@ void drawFPS(unsigned x, unsigned y) {
 	SDL_SetRenderDrawColor(renderer->sdlRenderer, prevR, prevG, prevB, prevA);
 }
 
+// auto save state utilities
+void updateAutoSaveState() {
+	double now = emscripten_get_now();
+
+	if (renderer->autoSaveStateTimer.lastTime == 0) {
+		renderer->autoSaveStateTimer.lastTime = now;
+		return;
+	}
+
+	double elapsed = now - renderer->autoSaveStateTimer.lastTime;
+	if (elapsed >= renderer->autoSaveStateTimer.intervalSeconds * 1000) {
+		bool successfulAutoSave = autoSaveState();
+		if (successfulAutoSave)
+			renderer->autoSaveStateTimer.lastTime = now;
+	}
+}
+
 // emscripten main run loop
 void runLoop() {
 	union SDL_Event event;
@@ -596,6 +666,9 @@ void runLoop() {
 			mSDLInitAudio(&renderer->audio, renderer->thread);
 			mSDLResumeAudio(&renderer->audio);
 			updateFastForward(renderer->fastForwardMultiplier);
+
+			if (renderer->restoreAutoSaveStateOnLoad)
+				loadAutoSaveState();
 		}
 
 		if (mCoreThreadIsActive(renderer->thread)) {
@@ -628,6 +701,8 @@ void runLoop() {
 		}
 		if (renderer->showFpsCounter)
 			updateFPS();
+		if (renderer->autoSaveStateEnable)
+			updateAutoSaveState();
 	} else {
 		// dont run the main loop if there is no core,  we don't
 		// want to handle events unless the core is running for now
@@ -697,6 +772,10 @@ int main() {
 	renderer->fpsCounter.lastTime = 0;
 	renderer->fpsCounter.fps = 0;
 	renderer->fpsCounter.frames = 0;
+	renderer->autoSaveStateEnable = true;
+	renderer->restoreAutoSaveStateOnLoad = true;
+	renderer->autoSaveStateTimer.lastTime = 0;
+	renderer->autoSaveStateTimer.intervalSeconds = 30;
 
 	mLogSetDefaultLogger(&logCtx);
 

--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -208,7 +208,6 @@ EMSCRIPTEN_KEEPALIVE void quitMgba() {
 
 EMSCRIPTEN_KEEPALIVE bool autoSaveState() {
 	if (renderer->core && renderer->thread) {
-		EM_ASM({ console.log('attempting to save auto save state') });
 		bool result = false;
 		struct VDir* autosaveDir = VDirOpen("/autosave");
 		char autoSaveName[PATH_MAX + 14];
@@ -224,7 +223,6 @@ EMSCRIPTEN_KEEPALIVE bool autoSaveState() {
 		mCoreThreadContinue(renderer->thread);
 		bool successfullyClosed = vf->close(vf);
 
-		EM_ASM({ console.log('auto save state completed with result', $0) }, result && successfullyClosed);
 		return result && successfullyClosed;
 	}
 
@@ -234,24 +232,18 @@ EMSCRIPTEN_KEEPALIVE bool autoSaveState() {
 EMSCRIPTEN_KEEPALIVE bool loadAutoSaveState() {
 	bool result = false;
 	if (renderer->core && renderer->thread) {
-		EM_ASM({ console.log('attempting to load auto save state') });
 		struct VDir* autosaveDir = VDirOpen("/autosave");
 		char autoSaveName[PATH_MAX + 14];
 		snprintf(autoSaveName, sizeof(autoSaveName), "%s_auto.ss", renderer->core->dirs.baseName);
 
 		struct VFile* vf = autosaveDir->openFile(autosaveDir, autoSaveName, O_RDONLY);
 
-		EM_ASM({ console.log('vf', $0) }, vf);
-
-		if (!vf) {
-			EM_ASM({ console.log('no vfile returning false early') });
+		if (!vf)
 			return false;
-		}
 
 		mCoreThreadInterrupt(renderer->thread);
 		result = mCoreLoadStateNamed(renderer->core, vf, SAVESTATE_ALL);
 		mCoreThreadContinue(renderer->thread);
-		EM_ASM({ console.log('loaded auto save state, result:', $0) }, result);
 		return result;
 	}
 	return false;

--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -29,6 +29,43 @@ static struct mEmscriptenRenderer* renderer = NULL;
 static void _log(struct mLogger*, int category, enum mLogLevel level, const char* format, va_list args);
 static struct mLogger logCtx = { .log = _log };
 
+// stored core callback function pointers
+typedef struct {
+	void (*alarm)(void*);
+	void (*coreCrashed)(void*);
+	void (*keysRead)(void*);
+	void (*savedataUpdated)(void*);
+	void (*videoFrameEnded)(void*);
+	void (*videoFrameStarted)(void*);
+	void (*autoSaveStateCaptured)(void*);
+	void (*autoSaveStateLoaded)(void*);
+} CallbackStorage;
+
+static CallbackStorage callbackStorage;
+
+// Macro to create wrapper functions, necessary as some core callbacks want to access
+// things like the file system on the CPU thread, which can only be done on the main thread.
+#define DEFINE_WRAPPER(field)                            \
+	static void wrapped_##field(void* context) {         \
+		MAIN_THREAD_EM_ASM(                              \
+		    {                                            \
+			    const funcPtr = $0;                      \
+			    const ctx = $1;                          \
+			    const func = wasmTable.get(funcPtr);     \
+			    if (func)                                \
+				    func(ctx);                           \
+		    },                                           \
+		    (int) callbackStorage.field, (int) context); \
+	}
+
+// Generate wrapper functions
+DEFINE_WRAPPER(alarm)
+DEFINE_WRAPPER(coreCrashed)
+DEFINE_WRAPPER(keysRead)
+DEFINE_WRAPPER(savedataUpdated)
+DEFINE_WRAPPER(videoFrameEnded)
+DEFINE_WRAPPER(videoFrameStarted)
+
 /**
  * Exposed core contract methods
  */
@@ -224,8 +261,11 @@ EMSCRIPTEN_KEEPALIVE void quickReload() {
 
 		renderer->core->reset(renderer->core);
 
-		if (renderer->restoreAutoSaveStateOnLoad)
-			loadAutoSaveState();
+		if (renderer->restoreAutoSaveStateOnLoad) {
+			bool successfulLoad = loadAutoSaveState();
+			if (successfulLoad && callbackStorage.autoSaveStateLoaded)
+				callbackStorage.autoSaveStateLoaded(NULL);
+		}
 
 		mCoreThreadContinue(renderer->thread);
 	}
@@ -409,45 +449,12 @@ EMSCRIPTEN_KEEPALIVE bool loadStateSlot(int slot, int flags) {
 	return mCoreLoadState(renderer->core, slot, flags);
 }
 
-typedef struct {
-	void (*alarm)(void*);
-	void (*coreCrashed)(void*);
-	void (*keysRead)(void*);
-	void (*savedataUpdated)(void*);
-	void (*videoFrameEnded)(void*);
-	void (*videoFrameStarted)(void*);
-} CallbackStorage;
-
-static CallbackStorage callbackStorage;
-
-// Macro to create wrapper functions
-#define DEFINE_WRAPPER(field)                            \
-	static void wrapped_##field(void* context) {         \
-		MAIN_THREAD_EM_ASM(                              \
-		    {                                            \
-			    const funcPtr = $0;                      \
-			    const ctx = $1;                          \
-			    const func = wasmTable.get(funcPtr);     \
-			    if (func)                                \
-				    func(ctx);                           \
-		    },                                           \
-		    (int) callbackStorage.field, (int) context); \
-	}
-
-// Generate wrapper functions
-DEFINE_WRAPPER(alarm)
-DEFINE_WRAPPER(coreCrashed)
-DEFINE_WRAPPER(keysRead)
-DEFINE_WRAPPER(savedataUpdated)
-DEFINE_WRAPPER(videoFrameEnded)
-DEFINE_WRAPPER(videoFrameStarted)
-
 // Function to ensure all callbacks execute on the main thread
-EMSCRIPTEN_KEEPALIVE void addCoreCallbacks(void (*alarmCallbackPtr)(void*), void (*coreCrashedCallbackPtr)(void*),
-                                           void (*keysReadCallbackPtr)(void*),
-                                           void (*saveDataUpdatedCallbackPtr)(void*),
-                                           void (*videoFrameEndedCallbackPtr)(void*),
-                                           void (*videoFrameStartedCallbackPtr)(void*)) {
+EMSCRIPTEN_KEEPALIVE void
+addCoreCallbacks(void (*alarmCallbackPtr)(void*), void (*coreCrashedCallbackPtr)(void*),
+                 void (*keysReadCallbackPtr)(void*), void (*saveDataUpdatedCallbackPtr)(void*),
+                 void (*videoFrameEndedCallbackPtr)(void*), void (*videoFrameStartedCallbackPtr)(void*),
+                 void (*autoSaveStateCapturedCallbackPtr)(void*), void (*autoSaveStateLoadedCallbackPtr)(void*)) {
 	if (renderer->core) {
 		struct mCoreCallbacks callbacks = {};
 		renderer->core->clearCoreCallbacks(renderer->core);
@@ -470,6 +477,12 @@ EMSCRIPTEN_KEEPALIVE void addCoreCallbacks(void (*alarmCallbackPtr)(void*), void
 			callbackStorage.videoFrameEnded = videoFrameEndedCallbackPtr;
 		if (videoFrameStartedCallbackPtr)
 			callbackStorage.videoFrameStarted = videoFrameStartedCallbackPtr;
+
+		// store original ad-hoc function pointers
+		if (autoSaveStateCapturedCallbackPtr)
+			callbackStorage.autoSaveStateCaptured = autoSaveStateCapturedCallbackPtr;
+		if (autoSaveStateLoadedCallbackPtr)
+			callbackStorage.autoSaveStateLoaded = autoSaveStateLoadedCallbackPtr;
 
 		// assign wrapped functions
 		if (alarmCallbackPtr)
@@ -651,8 +664,11 @@ void updateAutoSaveState() {
 	double elapsed = now - renderer->autoSaveStateTimer.lastTime;
 	if (elapsed >= renderer->autoSaveStateTimer.intervalSeconds * 1000) {
 		bool successfulAutoSave = autoSaveState();
-		if (successfulAutoSave)
+		if (successfulAutoSave) {
 			renderer->autoSaveStateTimer.lastTime = now;
+			if (callbackStorage.autoSaveStateCaptured)
+				callbackStorage.autoSaveStateCaptured(NULL);
+		}
 	}
 }
 
@@ -674,8 +690,11 @@ void runLoop() {
 			mSDLResumeAudio(&renderer->audio);
 			updateFastForward(renderer->fastForwardMultiplier);
 
-			if (renderer->restoreAutoSaveStateOnLoad)
-				loadAutoSaveState();
+			if (renderer->restoreAutoSaveStateOnLoad) {
+				bool successfulLoad = loadAutoSaveState();
+				if (successfulLoad && callbackStorage.autoSaveStateLoaded)
+					callbackStorage.autoSaveStateLoaded(NULL);
+			}
 		}
 
 		if (mCoreThreadIsActive(renderer->thread)) {

--- a/src/platform/wasm/main.h
+++ b/src/platform/wasm/main.h
@@ -13,6 +13,11 @@ typedef struct {
 	int frames;
 } FPSCounter;
 
+typedef struct {
+	double lastTime;
+	int intervalSeconds;
+} AutoSaveStateTimer;
+
 // represents global items used in rendering mGBA in the wasm platform
 struct mEmscriptenRenderer {
 	struct mCore* core;
@@ -22,11 +27,13 @@ struct mEmscriptenRenderer {
 	SDL_Texture* sdlTex;
 	SDL_Renderer* sdlRenderer;
 	FPSCounter fpsCounter;
+	AutoSaveStateTimer autoSaveStateTimer;
 
 	struct mSDLAudio audio;
 	struct mCoreThread* thread;
 
-	// persistent options for the core at runtime, limited subset of mCoreOptions
+	// persistent options for the core at runtime, limited
+	// subset of mCoreOptions and custom functionality
 	int fastForwardMultiplier;
 	int frameSkip;
 	int baseFpsTarget;
@@ -36,6 +43,8 @@ struct mEmscriptenRenderer {
 	bool threadedVideo;
 	bool rewindEnable;
 	bool showFpsCounter;
+	bool restoreAutoSaveStateOnLoad;
+	bool autoSaveStateEnable;
 	int rewindBufferCapacity;
 	int rewindBufferInterval;
 };

--- a/src/platform/wasm/main.h
+++ b/src/platform/wasm/main.h
@@ -37,6 +37,8 @@ struct mEmscriptenRenderer {
 	int fastForwardMultiplier;
 	int frameSkip;
 	int baseFpsTarget;
+	int rewindBufferCapacity;
+	int rewindBufferInterval;
 	bool videoSync;
 	bool audioSync;
 	bool timestepSync;
@@ -45,6 +47,4 @@ struct mEmscriptenRenderer {
 	bool showFpsCounter;
 	bool restoreAutoSaveStateOnLoad;
 	bool autoSaveStateEnable;
-	int rewindBufferCapacity;
-	int rewindBufferInterval;
 };

--- a/src/platform/wasm/mgba.d.ts
+++ b/src/platform/wasm/mgba.d.ts
@@ -31,6 +31,7 @@ declare namespace mGBA {
     rewindBufferInterval?: number;
     audioSampleRate?: number;
     audioBufferSize?: number;
+    autoSaveStateTimerIntervalSeconds?: number;
     allowOpposingDirections?: boolean;
     videoSync?: boolean;
     audioSync?: boolean;
@@ -38,6 +39,8 @@ declare namespace mGBA {
     rewindEnable?: boolean;
     timestepSync?: boolean;
     showFpsCounter?: boolean;
+    autoSaveStateEnable?: boolean;
+    restoreAutoSaveStateOnLoad?: boolean;
   };
 
   export interface mGBAEmulator extends EmscriptenModule {
@@ -57,6 +60,8 @@ declare namespace mGBA {
     listSaves(): string[];
     loadGame(romPath: string, savePathOverride?: string): boolean;
     loadState(slot: number): boolean;
+    forceAutoSaveState(): boolean;
+    loadAutoSaveState(): boolean;
     pauseAudio(): void;
     pauseGame(): void;
     quickReload(): void;
@@ -76,7 +81,7 @@ declare namespace mGBA {
     uploadSaveOrSaveState(file: File, callback?: () => void): void;
     addCoreCallbacks(coreCallbacks: coreCallbacks): void;
     toggleRewind(enabled: boolean): void;
-    setCoreSettings(coreSettings: CoreSettings): void;
+    setCoreSettings(coreSettings: coreSettings): void;
     // custom variables
     version: {
       projectName: string;

--- a/src/platform/wasm/mgba.d.ts
+++ b/src/platform/wasm/mgba.d.ts
@@ -22,6 +22,8 @@ declare namespace mGBA {
     saveDataUpdatedCallback?: (() => void) | null;
     videoFrameEndedCallback?: (() => void) | null;
     videoFrameStartedCallback?: (() => void) | null;
+    autoSaveStateCapturedCallback?: (() => void) | null;
+    autoSaveStateLoadedCallback?: (() => void) | null;
   };
 
   export type coreSettings = {

--- a/src/platform/wasm/mgba.d.ts
+++ b/src/platform/wasm/mgba.d.ts
@@ -62,6 +62,11 @@ declare namespace mGBA {
     loadState(slot: number): boolean;
     forceAutoSaveState(): boolean;
     loadAutoSaveState(): boolean;
+    getAutoSaveState(): { autoSaveStateName: string; data: Uint8Array };
+    uploadAutoSaveState(
+      autoSaveStateName: string,
+      data: Uint8Array
+    ): Promise<void>;
     pauseAudio(): void;
     pauseGame(): void;
     quickReload(): void;
@@ -90,6 +95,7 @@ declare namespace mGBA {
     filePaths(): filePaths;
     gameName?: string;
     saveName?: string;
+    autoSaveStateName?: string;
     // extra exported runtime methods
     FS: typeof FS;
     // SDL2

--- a/src/platform/wasm/package.json
+++ b/src/platform/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thenick775/mgba-wasm",
-  "version": "2.3.0-beta.1",
+  "version": "2.3.0-beta.2",
   "description": "mGBA emulator compiled to webassembly",
   "main": "./dist/mgba.js",
   "types": "./dist/mgba.d.ts",

--- a/src/platform/wasm/package.json
+++ b/src/platform/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thenick775/mgba-wasm",
-  "version": "2.2.2",
+  "version": "2.3.0-beta.1",
   "description": "mGBA emulator compiled to webassembly",
   "main": "./dist/mgba.js",
   "types": "./dist/mgba.d.ts",

--- a/src/platform/wasm/pre.js
+++ b/src/platform/wasm/pre.js
@@ -339,7 +339,6 @@ Module.loadAutoSaveState = () => {
 };
 
 Module.getAutoSaveState = () => {
-  console.log('vancise in getAutoSaveState', Module.autoSaveStateName);
   return {
     autoSaveStateName: Module.autoSaveStateName,
     data: FS.readFile(Module.autoSaveStateName),
@@ -527,12 +526,6 @@ Module.setCoreSettings = (coreSettings) => {
     setIntegerCoreSetting(
       'autoSaveStateEnable',
       coreSettings.autoSaveStateEnable
-    );
-
-  if (coreSettings.autoSaveStateTimerIntervalSeconds !== undefined)
-    setIntegerCoreSetting(
-      'autoSaveStateTimerIntervalSeconds',
-      coreSettings.autoSaveStateTimerIntervalSeconds
     );
 
   if (coreSettings.restoreAutoSaveStateOnLoad !== undefined)

--- a/src/platform/wasm/pre.js
+++ b/src/platform/wasm/pre.js
@@ -420,6 +420,8 @@ const coreCallbackStore = {
   saveDataUpdatedCallbackPtr: null,
   videoFrameEndedCallbackPtr: null,
   videoFrameStartedCallbackPtr: null,
+  autoSaveStateCapturedCallbackPtr: null,
+  autoSaveStateLoadedCallbackPtr: null,
 };
 
 // adds user callbacks to the callback store, and makes function(s) available to the core in c
@@ -449,7 +451,9 @@ Module.addCoreCallbacks = (callbacks) => {
     coreCallbackStore.keysReadCallbackPtr,
     coreCallbackStore.saveDataUpdatedCallbackPtr,
     coreCallbackStore.videoFrameEndedCallbackPtr,
-    coreCallbackStore.videoFrameStartedCallbackPtr
+    coreCallbackStore.videoFrameStartedCallbackPtr,
+    coreCallbackStore.autoSaveStateCapturedCallbackPtr,
+    coreCallbackStore.autoSaveStateLoadedCallbackPtr
   );
 };
 

--- a/src/platform/wasm/pre.js
+++ b/src/platform/wasm/pre.js
@@ -12,10 +12,15 @@ Module.loadGame = (romPath, savePathOverride) => {
     arr.pop();
 
     const saveName = arr.join('.') + '.sav';
+    const autoSaveStateName = arr.join('.') + '_auto.ss';
 
     Module.gameName = romPath;
     Module.saveName =
       savePathOverride ?? saveName.replace('/data/games/', '/data/saves/');
+    Module.autoSaveStateName = autoSaveStateName.replace(
+      '/data/games/',
+      '/autosave/'
+    );
     return true;
   }
 
@@ -331,6 +336,37 @@ Module.forceAutoSaveState = () => {
 Module.loadAutoSaveState = () => {
   const loadAutoSaveState = cwrap('loadAutoSaveState', 'boolean', []);
   return loadAutoSaveState();
+};
+
+Module.getAutoSaveState = () => {
+  console.log('vancise in getAutoSaveState', Module.autoSaveStateName);
+  return {
+    autoSaveStateName: Module.autoSaveStateName,
+    data: FS.readFile(Module.autoSaveStateName),
+  };
+};
+
+Module.uploadAutoSaveState = async (autoSaveStateName, data) => {
+  return new Promise((resolve, reject) => {
+    try {
+      if (!(data instanceof Uint8Array)) {
+        console.warn('Auto save state data must be a Uint8Array');
+        return;
+      }
+
+      if (!autoSaveStateName.length) {
+        console.warn('Auto save state file name invalid');
+        return;
+      }
+
+      const path = `${autoSaveStateName}`;
+      FS.writeFile(path, data);
+
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
 };
 
 Module.saveStateSlot = (slot, flags) => {

--- a/src/platform/wasm/pre.js
+++ b/src/platform/wasm/pre.js
@@ -34,11 +34,14 @@ Module.listSaves = () => {
   return FS.readdir('/data/saves/');
 };
 
-// yanked from main.c for ease of use
 Module.FSInit = () => {
   return new Promise((resolve, reject) => {
     FS.mkdir('/data');
     FS.mount(FS.filesystems.IDBFS, {}, '/data');
+
+    // mount auto save directory, this should auto persist, while the data mount should not
+    FS.mkdir('/autosave');
+    FS.mount(FS.filesystems.IDBFS, { autoPersist: true }, '/autosave');
 
     // load data from IDBFS
     FS.syncfs(true, (err) => {
@@ -320,6 +323,16 @@ Module.loadState = (slot) => {
   return loadState(slot);
 };
 
+Module.forceAutoSaveState = () => {
+  const autoSaveState = cwrap('autoSaveState', 'boolean', []);
+  return autoSaveState();
+};
+
+Module.loadAutoSaveState = () => {
+  const loadAutoSaveState = cwrap('loadAutoSaveState', 'boolean', []);
+  return loadAutoSaveState();
+};
+
 Module.saveStateSlot = (slot, flags) => {
   var saveStateSlot = cwrap('saveStateSlot', 'number', ['number', 'number']);
   Module.saveStateSlot = (slot, flags) => {
@@ -463,4 +476,28 @@ Module.setCoreSettings = (coreSettings) => {
 
   if (coreSettings.showFpsCounter !== undefined)
     setIntegerCoreSetting('showFpsCounter', coreSettings.showFpsCounter);
+
+  if (coreSettings.autoSaveStateTimerIntervalSeconds !== undefined)
+    setIntegerCoreSetting(
+      'autoSaveStateTimerIntervalSeconds',
+      coreSettings.autoSaveStateTimerIntervalSeconds
+    );
+
+  if (coreSettings.autoSaveStateEnable !== undefined)
+    setIntegerCoreSetting(
+      'autoSaveStateEnable',
+      coreSettings.autoSaveStateEnable
+    );
+
+  if (coreSettings.autoSaveStateTimerIntervalSeconds !== undefined)
+    setIntegerCoreSetting(
+      'autoSaveStateTimerIntervalSeconds',
+      coreSettings.autoSaveStateTimerIntervalSeconds
+    );
+
+  if (coreSettings.restoreAutoSaveStateOnLoad !== undefined)
+    setIntegerCoreSetting(
+      'restoreAutoSaveStateOnLoad',
+      coreSettings.restoreAutoSaveStateOnLoad
+    );
 };


### PR DESCRIPTION
### High Level Details

- adds support for auto save state
   - includes callbacks for notifications
- includes states/controls for
   - auto save state ON/OFF
   - restore auto save state on load ON/OFF
   - auto save state interval
- exposes callbacks for
   - taking an auto save state
   - loading an auto save state
   - uploading an auto save state
   
### Implementation details

- auto save states are mounted in their own IDBFS mount, so they can auto persist separately from the `/data/ mount that users can control
- the auto save state capture is currently based on time in the main browser thread, for simplicities sake for now

Note: currently in beta release `2.3.0-beta.2`