### PR TITLE
fix: clearing ad-hoc function pointers

### DIFF
--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -455,7 +455,12 @@ addCoreCallbacks(void (*alarmCallbackPtr)(void*), void (*coreCrashedCallbackPtr)
                  void (*autoSaveStateCapturedCallbackPtr)(void*), void (*autoSaveStateLoadedCallbackPtr)(void*)) {
 	if (renderer->core) {
 		struct mCoreCallbacks callbacks = {};
+		// clear core callbacks
 		renderer->core->clearCoreCallbacks(renderer->core);
+		// clear ad-hoc callbacks
+		callbackStorage.autoSaveStateCaptured = NULL;
+		callbackStorage.autoSaveStateLoaded = NULL;
+
 		// the thread has its own suite of callbacks where ours should overlay on top,
 		// after clearing the current core callbacks since there is not a mechanism to
 		// filter the callbacks, we need to re-add the thread callbacks


### PR DESCRIPTION
- the lack of proper clearing is causing the following exception:
   ```
   mgba.js:603 Uncaught RuntimeError: null function or function signature mismatch
   ```