### PR TITLE
feat: wasm - allow slowdown (negative fast forward multipliers)

### DIFF
--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -149,7 +149,7 @@ EMSCRIPTEN_KEEPALIVE void setMainLoopTiming(int mode, int value) {
 }
 
 // full handling of fast forward, interrupts and thread logic included
-void updateFastForward(int multiplier) {
+void updateFastForward(double multiplier) {
 	if (renderer->thread && renderer->videoSync) {
 		mCoreThreadInterrupt(renderer->thread);
 		renderer->thread->impl->sync.videoFrameWait = (multiplier > 1) ? false : renderer->videoSync;
@@ -157,7 +157,7 @@ void updateFastForward(int multiplier) {
 		mCoreThreadContinue(renderer->thread);
 	}
 
-	if (renderer->core && renderer->thread && multiplier > 0) {
+	if (renderer->core && renderer->thread && multiplier != 0) {
 		renderer->thread->impl->sync.fpsTarget = (double) renderer->baseFpsTarget * multiplier;
 		mCoreConfigSetDefaultFloatValue(&renderer->core->config, "fpsTarget",
 		                                (double) renderer->baseFpsTarget * multiplier);
@@ -172,10 +172,13 @@ void updateFastForward(int multiplier) {
 }
 
 EMSCRIPTEN_KEEPALIVE void setFastForwardMultiplier(int multiplier) {
-	if (multiplier > 0)
+	if (multiplier > 0) {
 		renderer->fastForwardMultiplier = multiplier;
+	} else if (multiplier < 0) {
+		renderer->fastForwardMultiplier = -1.0 / (double) multiplier;
+	}
 
-	updateFastForward(multiplier);
+	updateFastForward(renderer->fastForwardMultiplier);
 }
 
 EMSCRIPTEN_KEEPALIVE int getFastForwardMultiplier() {

--- a/src/platform/wasm/main.h
+++ b/src/platform/wasm/main.h
@@ -34,7 +34,7 @@ struct mEmscriptenRenderer {
 
 	// persistent options for the core at runtime, limited
 	// subset of mCoreOptions and custom functionality
-	int fastForwardMultiplier;
+	double fastForwardMultiplier;
 	int frameSkip;
 	int baseFpsTarget;
 	int rewindBufferCapacity;

--- a/src/platform/wasm/package.json
+++ b/src/platform/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thenick775/mgba-wasm",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "description": "mGBA emulator compiled to webassembly",
   "main": "./dist/mgba.js",
   "types": "./dist/mgba.d.ts",


### PR DESCRIPTION
- not the most understandable thing for now, but works as expected, negative fast forward multiplier -> relative slowdown based on the baseFpsTarget in a 1/X * baseFpsTarget format