### PR TITLE
feat: callback handling for external structured logging interception

### DIFF
--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -855,7 +855,7 @@ int main() {
 	renderer->autoSaveStateTimer.intervalSeconds = 30;
 
 	mLogFilterInit(&logFilter);
-	logFilter.defaultLevels = mLOG_FATAL | mLOG_ERROR;
+	logFilter.defaultLevels = 0;
 	logCtx.filter = &logFilter;
 
 	mLogSetDefaultLogger(&logCtx);

--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -27,7 +27,11 @@ static struct mEmscriptenRenderer* renderer = NULL;
 
 // log utilities
 static void _log(struct mLogger*, int category, enum mLogLevel level, const char* format, va_list args);
-static struct mLogger logCtx = { .log = _log };
+static struct mLogFilter logFilter;
+static struct mLogger logCtx = {
+	.log = _log,
+	.filter = &logFilter,
+};
 static void (*logCallback)(int, const char*, const char*) = NULL;
 
 static void wrapped_log(int level, const char* categoryName, const char* message) {
@@ -524,6 +528,7 @@ addCoreCallbacks(void (*alarmCallbackPtr)(void*), void (*coreCrashedCallbackPtr)
 
 EMSCRIPTEN_KEEPALIVE void setLogCallback(void (*logCallbackPtr)(int, const char*, const char*)) {
 	logCallback = logCallbackPtr;
+	logCtx.filter = logCallbackPtr ? NULL : &logFilter;
 }
 
 EMSCRIPTEN_KEEPALIVE void setIntegerCoreSetting(char* settingName, int value) {
@@ -848,6 +853,10 @@ int main() {
 	renderer->restoreAutoSaveStateOnLoad = true;
 	renderer->autoSaveStateTimer.lastTime = 0;
 	renderer->autoSaveStateTimer.intervalSeconds = 30;
+
+	mLogFilterInit(&logFilter);
+	logFilter.defaultLevels = mLOG_FATAL | mLOG_ERROR;
+	logCtx.filter = &logFilter;
 
 	mLogSetDefaultLogger(&logCtx);
 

--- a/src/platform/wasm/main.c
+++ b/src/platform/wasm/main.c
@@ -28,6 +28,18 @@ static struct mEmscriptenRenderer* renderer = NULL;
 // log utilities
 static void _log(struct mLogger*, int category, enum mLogLevel level, const char* format, va_list args);
 static struct mLogger logCtx = { .log = _log };
+static void (*logCallback)(int, const char*, const char*) = NULL;
+
+static void wrapped_log(int level, const char* categoryName, const char* message) {
+	MAIN_THREAD_EM_ASM(
+	    {
+		    const funcPtr = $0;
+		    const func = wasmTable.get(funcPtr);
+		    if (func)
+			    func($1, $2, $3);
+	    },
+	    (int) logCallback, level, categoryName, message);
+}
 
 // stored core callback function pointers
 typedef struct {
@@ -459,7 +471,7 @@ addCoreCallbacks(void (*alarmCallbackPtr)(void*), void (*coreCrashedCallbackPtr)
                  void (*videoFrameEndedCallbackPtr)(void*), void (*videoFrameStartedCallbackPtr)(void*),
                  void (*autoSaveStateCapturedCallbackPtr)(void*), void (*autoSaveStateLoadedCallbackPtr)(void*)) {
 	if (renderer->core) {
-		struct mCoreCallbacks callbacks = {};
+		struct mCoreCallbacks callbacks = { };
 		// clear core callbacks
 		renderer->core->clearCoreCallbacks(renderer->core);
 		// clear ad-hoc callbacks
@@ -508,6 +520,10 @@ addCoreCallbacks(void (*alarmCallbackPtr)(void*), void (*coreCrashedCallbackPtr)
 
 		renderer->core->addCoreCallbacks(renderer->core, &callbacks);
 	}
+}
+
+EMSCRIPTEN_KEEPALIVE void setLogCallback(void (*logCallbackPtr)(int, const char*, const char*)) {
+	logCallback = logCallbackPtr;
 }
 
 EMSCRIPTEN_KEEPALIVE void setIntegerCoreSetting(char* settingName, int value) {
@@ -695,6 +711,7 @@ void runLoop() {
 			memset(renderer->thread, 0, sizeof(struct mCoreThread));
 
 			renderer->thread->core = renderer->core;
+			renderer->thread->logger.logger = &logCtx;
 			bool didFail = !mCoreThreadStart(renderer->thread);
 			if (didFail)
 				EM_ASM({ console.error("thread instantiation failed") });
@@ -755,10 +772,26 @@ void runLoop() {
 
 void _log(struct mLogger* logger, int category, enum mLogLevel level, const char* format, va_list args) {
 	UNUSED(logger);
-	UNUSED(category);
-	UNUSED(level);
-	UNUSED(format);
-	UNUSED(args);
+
+	char buffer[2048];
+	const char* categoryName = mLogCategoryName(category);
+
+	vsnprintf(buffer, sizeof(buffer), format, args);
+
+	if (!categoryName) {
+		categoryName = "";
+	}
+
+	if (!logCallback) {
+		if (categoryName[0]) {
+			printf("%s: %s\n", categoryName, buffer);
+		} else {
+			printf("%s\n", buffer);
+		}
+		return;
+	}
+
+	wrapped_log((int) level, categoryName, buffer);
 }
 
 EMSCRIPTEN_KEEPALIVE void setupConstants(void) {

--- a/src/platform/wasm/mgba.d.ts
+++ b/src/platform/wasm/mgba.d.ts
@@ -60,6 +60,21 @@ declare namespace mGBA {
     autoSaveStateLoadedCallback?: (() => void) | null;
   };
 
+  export type LogLevel =
+    | 'FATAL'
+    | 'ERROR'
+    | 'WARN'
+    | 'INFO'
+    | 'DEBUG'
+    | 'STUB'
+    | 'GAME ERROR';
+
+  export type LogEntry = {
+    level: LogLevel;
+    category: string;
+    message: string;
+  };
+
   export type coreSettings = {
     /**
      * Number of frames to skip rendering between screen paints.
@@ -480,6 +495,19 @@ declare namespace mGBA {
      * @param coreCallbacks - Callback object to register.
      */
     addCoreCallbacks(coreCallbacks: coreCallbacks): void;
+
+    /**
+     * Registers a callback for mGBA core log output.
+     *
+     * Use this to capture emulator logs in your application UI, such as a log
+     * panel, instead of relying on browser console output alone.
+     *
+     * Passing `null` removes the custom logger and restores default console
+     * logging.
+     *
+     * @param callback - Log handler, or `null` to clear it.
+     */
+    setLogger(callback: ((entry: LogEntry) => void) | null): void;
 
     /**
      * Enables/disables active rewinding while the core is running.

--- a/src/platform/wasm/package.json
+++ b/src/platform/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thenick775/mgba-wasm",
-  "version": "2.4.1",
+  "version": "2.5.0-beta.3",
   "description": "mGBA emulator compiled to webassembly",
   "main": "./dist/mgba.js",
   "types": "./dist/mgba.d.ts",

--- a/src/platform/wasm/package.json
+++ b/src/platform/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thenick775/mgba-wasm",
-  "version": "2.5.0-beta.3",
+  "version": "2.4.1",
   "description": "mGBA emulator compiled to webassembly",
   "main": "./dist/mgba.js",
   "types": "./dist/mgba.d.ts",

--- a/src/platform/wasm/pre.js
+++ b/src/platform/wasm/pre.js
@@ -445,6 +445,45 @@ Module.getFastForwardMultiplier = () => {
   return getFastForwardMultiplier();
 };
 
+const logLevels = {
+  1: 'FATAL',
+  2: 'ERROR',
+  4: 'WARN',
+  8: 'INFO',
+  16: 'DEBUG',
+  32: 'STUB',
+  64: 'GAME ERROR',
+};
+
+const loggerStore = {
+  callbackPtr: null,
+};
+
+Module.setLogger = (callback) => {
+  const setLogCallback = cwrap('setLogCallback', null, ['number']);
+
+  if (loggerStore.callbackPtr) {
+    removeFunction(loggerStore.callbackPtr);
+    loggerStore.callbackPtr = null;
+  }
+
+  if (typeof callback === 'function') {
+    loggerStore.callbackPtr = addFunction(
+      (levelValue, categoryPtr, messagePtr) => {
+        const level = logLevels[levelValue] ?? 'INFO';
+        callback({
+          level,
+          category: UTF8ToString(categoryPtr),
+          message: UTF8ToString(messagePtr),
+        });
+      },
+      'viii'
+    );
+  }
+
+  setLogCallback(loggerStore.callbackPtr);
+};
+
 // core callback store, used to persist long lived js function pointers for use in core callbacks in c
 const coreCallbackStore = {
   alarmCallbackPtr: null,


### PR DESCRIPTION
- idea here is to expose and api for when standard emscripten printf logging to the browser needs to be intercepted and presented in a different manner

- initial usecase here is this issue, Closes #34

- this follows standard callback structure in this contract (for better or worse right now), and exposes structured logging fields with no formatting preference